### PR TITLE
feature(aux-ts): add dataFeed address and public key

### DIFF
--- a/aptos/api/aux-ts/src/clob/core/query.ts
+++ b/aptos/api/aux-ts/src/clob/core/query.ts
@@ -1,4 +1,4 @@
-import { AptosAccount, HexString, Types } from "aptos";
+import { HexString, Types } from "aptos";
 import BN from "bn.js";
 import { AuxClient, CoinInfo, parseTypeArgs } from "../../client";
 import { AtomicUnits, AU, DecimalUnits } from "../../units";
@@ -213,18 +213,13 @@ export async function market(
   const rawMarket = resource as any as RawMarket;
 
   const tickSize = new AtomicUnits(rawMarket.data.tick_size);
-  const sender = new AptosAccount();
-  // FIXME hack
-  await auxClient.faucetClient?.fundAccount(sender.address(), 100000000);
   const payload = {
     function: `${auxClient.moduleAddress}::clob_market::load_market_into_event`,
     type_arguments: [baseCoinType, quoteCoinType],
     arguments: [],
   };
-  const txResult = await auxClient.generateSignSubmitWaitForTransaction({
-    sender,
+  const txResult = await auxClient.dataSimulate({
     payload,
-    transactionOptions: { simulate: true },
   });
 
   const l2 = txResult.events[0];


### PR DESCRIPTION
data feed user can read tables for order book and emit them into an event queue. With data feed public key and address, the client can simulate the reading operation on chain and get the resulted events (market data) without paying any gas.

There are offical data feed for aux on devnet and testnet, and we use the localnet deployment account as the data feed user.

If user of the library sets up an account for specific network and saved it in the profile config, it will be used in lieu of the official one.