### PR TITLE
chore: downgrade aptos to v1.0.0

### DIFF
--- a/aptos/contract/aux/Move.toml
+++ b/aptos/contract/aux/Move.toml
@@ -14,7 +14,7 @@ deployer = '0x8686'
 
 [dependencies.AptosFramework]
 git = 'https://github.com/aptos-labs/aptos-core.git'
-rev = 'aptos-cli-v1.0.1'
+rev = 'aptos-cli-v1.0.0'
 subdir = 'aptos-move/framework/aptos-framework'
 
 [dependencies.deployer]


### PR DESCRIPTION
aptos v1.0.1 is reporting error when `aptos move test`

```sh
{
  "Error": "Unexpected error: Unable to resolve packages for package 'aux'"
}
```