### PR TITLE
feature(aux): reward distributor

### DIFF
--- a/aptos/contract/aux/sources/quote_coin.move
+++ b/aptos/contract/aux/sources/quote_coin.move
@@ -1,0 +1,79 @@
+/// quote_coin emulates the aptos_framework::coin, but is for calculating or "quoting".
+/// All operations on aptos_framework::coin are replicated here for `u64`, so the 
+/// allows users to create and destroy arbitrary amounts. For example, user can simply
+/// replace `coin::extract` with `quote_coin::extract`.
+module aux::quote_coin {
+    /// Coin Treasury is used to track the total supply of the coin.
+    /// Together with `mint` or `burn` functions,
+    /// it can simulate the function of a coin's `MintCapability` and `BurnCapability`
+    struct CoinTreasury has store, copy, drop {
+        supply: u128
+    }
+
+    /// new creates a new quote_coin.
+    public fun new(value: u64): u64 {
+        value
+    }
+
+    /// destroy a quote_coin
+    public fun destroy(coin: u64) {
+        let _ = coin;
+    }
+
+    /// create a new CoinTreasury to track the total supply of the
+    /// coin.
+    public fun new_coin_treasury(supply: u128): CoinTreasury {
+        CoinTreasury {
+            supply,
+        }
+    }
+
+    /// Destroy CoinTreasury
+    public fun destroy_coin_treasury(treasury: CoinTreasury) {
+        let CoinTreasury { supply: _ } = treasury;
+    }
+
+    public fun treasury_supply(treasury: &CoinTreasury): u128 {
+        treasury.supply
+    }
+
+    /****************************/
+    /*  coin functions          */
+    /****************************/
+
+    public fun zero(): u64 {
+        0
+    }
+
+    public fun merge(coin: &mut u64, other: u64) {
+        *coin = *coin + other;
+    }
+
+    public fun extract(coin: &mut u64, amount: u64): u64 {
+        *coin = *coin - amount;
+        amount
+    }
+
+    public fun extract_all(coin: &mut u64): u64 {
+        let r = *coin;
+        *coin = 0;
+        r
+    }
+
+    public fun value(coin: &u64): u64 {
+        *coin
+    }
+
+    public fun destory_zero(coin: u64) {
+        assert!(coin == 0, coin);
+    }
+
+    public fun mint(amount: u64, mint_cap: &mut CoinTreasury): u64 {
+        mint_cap.supply = mint_cap.supply + (amount as u128);
+        amount
+    }
+
+    public fun burn(coin: u64, mint_cap: &mut CoinTreasury) {
+        mint_cap.supply = mint_cap.supply - (coin as u128);
+    }
+}

--- a/aptos/contract/aux/sources/reward_distributor.move
+++ b/aptos/contract/aux/sources/reward_distributor.move
@@ -1,0 +1,330 @@
+// Auto generated from "go-util/aptos/cmd/gen-reward-distributor"
+// Modify Manually with Caution
+module aux::reward_distributor {
+    use std::signer;
+
+    use aptos_framework::coin::{Self, Coin};
+    use aptos_framework::type_info;
+    use aux::reward_quoter::{Self, RewardDistributionQuoter};
+
+    const E_MISMATCH_DISTRIBUTOR_ID: u64 = 1002;
+    const E_CANNOT_CREATE_DISTRIBUTOR_FOR_OTHER: u64 = 1003;
+    const E_ZERO_MINT_AMOUNT: u64 = 1004;
+    const E_CANNOT_SHUTDOWN_DISTRIBUTOR_WITH_OUTSTANDING_TOKEN: u64 = 1005;
+    const E_REDEEM_TOKEN_NOT_FUNGIBLE: u64 = 1006;
+    const E_CANNOT_DESTROY_NON_ZERO_REDEEM_TOKEN: u64 = 1007;
+    const E_CANNOT_MELT_TOKEN_FOR_DIFFERNT_DISTRIBUTOR: u64 = 1008;
+
+    const DECIMAL_MULTIPLIER: u128 = 1000000000000;
+
+    /// RewardDistributor is a primitive for distributing rewards to token holders.
+    ///
+    /// Reward is given out in the form of 0x1::coin::Coin<R>.
+    ///
+    /// RewardDistributor keeps track of acc_reward_per_share, that is,
+    /// the amount of reward per unit token if that token exists since the initialization of the distributor.
+    /// When reward is added to the RewardDistrubitor,
+    /// acc_reward_per_share is increased by the amount of added_reward / total_token_amount.
+    ///
+    /// Users' rewards are represented by RedeemToken.
+    /// Users are entitled to rewards that are added after their RedeemToken are mint.
+    /// This is ensured by keeping in RedeemToken last_acc_reward_per_share, which is the
+    /// acc_reward_per_share when the RedeemToken is minted.
+    /// When RedeemTokens are burned, the returned reward will be based on
+    /// current RewardDistributor's acc_reward_per_share minus RedeemToken's last_acc_reward_per_share.
+    ///
+    /// In reality, acc_reward_per_share is multiplied by 10^12 to increase the precision of calculations.
+    /// However, rounding is unavoidable, and there may still be reward left when total token amount is 0.
+    ///
+    /// When total token amount drops to 0, RewardDistributor can be shutdown and rewards returned to the authority
+    /// of the distributor.
+    ///
+    /// W is the witness type. Only owner of the witness type can create a RewardDistributor with W.
+    ///
+    /// There can be multiple RewardDistributors for the same reward coin R and witness W. They are differentiated by their id.
+    /// Each RewardDistributor has separate authority even if they are of same reward coin R.
+    struct RewardDistributor<phantom R, phantom W> has store {
+        id: u128,
+        /// reward coins
+        reward: Coin<R>,
+        /// total_token_amount is the **current** outstanding RedeemToken for this distributor.
+        total_token_amount: u128,
+        /// accumulative reward per share, if the token is held from initialization of the pool.
+        acc_reward_per_share: u128,
+    }
+
+    /// RedeemToken contains the information useful for redeeming reward from RewardDistributor.
+    ///
+    /// It contains the number of tokens, and the `last_acc_reward_per_share`.
+    /// When RedeemToken is burned, reward will be calculated based on
+    /// value * (reward_distributor.acc_reward_per_share - token.last_acc_reward_per_share) / DECIMAL_MULTIPLIER.
+    struct RedeemToken<phantom R, phantom W> has store {
+        // id of the distributor
+        id: u128,
+        value: u64,
+        last_acc_reward_per_share: u128,
+    }
+
+    /// create a new RewardDistributor.
+    public fun create_reward_distributor<R, W>(sender: &signer, id: u128): RewardDistributor<R, W> {
+        assert!(
+            signer::address_of(sender) == type_info::account_address(&type_info::type_of<W>()),
+            E_CANNOT_CREATE_DISTRIBUTOR_FOR_OTHER,
+        );
+        RewardDistributor {
+            id,
+            reward: coin::zero(),
+            total_token_amount: 0,
+            acc_reward_per_share: 0,
+        }
+    }
+
+    /// Add rewards to the distributor.
+    ///
+    /// To make sure no front running, only add reward when all the current token holders are entitled to the rewards.
+    /// For example, if a liquidity pool is using RewardDistributor to distribute fees to its lps.
+    /// The fees should be added to the pool **BEFORE** lp tokens are minted or burned.
+    ///
+    /// Note this function permits anyone to add reward to the pool.
+    /// Once the reward is added, there is no way to retrieve the reward before all tokens are redeemed/burned.
+    ///
+    /// If the total token amount is 0, the reward will be not able to be redeemable for users.
+    public fun add_reward<R, W>(distributor: &mut RewardDistributor<R, W>, reward: Coin<R>) {
+        let value = (coin::value(&reward) as u128);
+
+        coin::merge(&mut distributor.reward, reward);
+
+        // only increment the acc_reward_per_share when total token amount > 0.
+        // this means the reward will stuck in the distributor if total token amount is 0.
+        // the authority of the pool can still retrieve the reward once there is no outstanding token holders.
+        if (distributor.total_token_amount > 0) {
+            distributor.acc_reward_per_share = distributor.acc_reward_per_share + (value * DECIMAL_MULTIPLIER)/distributor.total_token_amount;
+        }
+    }
+
+    /// mint new redeem tokens.
+    public fun mint<R, W>(
+        distributor: &mut RewardDistributor<R, W>,
+        amount: u64,
+    ): RedeemToken<R, W>
+    {
+        assert!(amount > 0, E_ZERO_MINT_AMOUNT);
+
+        distributor.total_token_amount = distributor.total_token_amount + (amount as u128);
+
+        RedeemToken {
+            id: distributor.id,
+            value: amount,
+            last_acc_reward_per_share: distributor.acc_reward_per_share,
+        }
+    }
+
+    /// burn RedeemTokens and get reward
+    public fun burn<R, W>(
+        distributor: &mut RewardDistributor<R, W>,
+        tokens: RedeemToken<R, W>,
+    ): Coin<R> {
+        assert!(tokens.id == distributor.id, E_MISMATCH_DISTRIBUTOR_ID);
+
+        distributor.total_token_amount = distributor.total_token_amount - (tokens.value as u128);
+        let reward_amount = ((distributor.acc_reward_per_share - tokens.last_acc_reward_per_share) * (tokens.value as u128)) / DECIMAL_MULTIPLIER;
+        let reward_amount = (reward_amount as u64);
+
+        let rewards = coin::extract(&mut distributor.reward, reward_amount);
+
+        let RedeemToken {
+            value: _,
+            id: _,
+            last_acc_reward_per_share: _,
+        } = tokens;
+
+        rewards
+    }
+
+    /// rebase will withdraw the current reward amount, and
+    /// replace the old token with new tokens.
+    public fun rebase<R, W>(
+        distributor: &mut RewardDistributor<R, W>,
+        tokens: RedeemToken<R, W>,
+    ): (Coin<R>, RedeemToken<R, W>) {
+        assert!(tokens.id == distributor.id, E_MISMATCH_DISTRIBUTOR_ID);
+
+        let reward_amount = ((distributor.acc_reward_per_share - tokens.last_acc_reward_per_share) * (tokens.value as u128)) / DECIMAL_MULTIPLIER;
+        let reward_amount = (reward_amount as u64);
+
+        let rewards = coin::extract(&mut distributor.reward, reward_amount);
+
+         let RedeemToken {
+            value,
+            id,
+            last_acc_reward_per_share: _,
+        } = tokens;
+
+        (
+            rewards,
+            RedeemToken {
+                value,
+                id,
+                last_acc_reward_per_share: distributor.acc_reward_per_share,
+            },
+        )
+    }
+
+    /// shutdown the distributor. The total outstanding token amount must be 0.
+    public fun shutdown<R, W>(distributor: RewardDistributor<R, W>): Coin<R> {
+        assert!(
+            distributor.total_token_amount == 0,
+            E_CANNOT_SHUTDOWN_DISTRIBUTOR_WITH_OUTSTANDING_TOKEN,
+        );
+
+        let RewardDistributor<R, W> {
+            reward: remaining_rewards,
+            id: _,
+            total_token_amount: _,
+            acc_reward_per_share: _,
+        } = distributor;
+
+        remaining_rewards
+    }
+
+    /*********************************/
+    /* RewardDistributor functions   */
+    /*********************************/
+
+    public fun acc_reward_per_share<R, W>(distributor: &RewardDistributor<R, W>): u128 {
+        distributor.acc_reward_per_share
+    }
+
+    public fun distributor_id<R, W>(distributor: &RewardDistributor<R, W>): u128 {
+        distributor.id
+    }
+
+    public fun total_token_amount<R, W>(distributor: &RewardDistributor<R, W>): u128 {
+        distributor.total_token_amount
+    }
+
+    public fun available_reward<R, W>(distributor: &RewardDistributor<R, W>): u64 {
+        coin::value(&distributor.reward)
+    }
+
+    /// check if token is for this RewardDistributor
+    public fun check_redeem_token<R, W>(distributor: &RewardDistributor<R, W>, token: &RedeemToken<R, W>): bool {
+        distributor.id == token.id
+    }
+
+    /// compute the reward amount for the given token.
+    public fun reward_amount<R, W>(distributor: &RewardDistributor<R, W>, token: &RedeemToken<R, W>): u64 {
+        assert!(
+            distributor.id == token.id,
+            E_MISMATCH_DISTRIBUTOR_ID,
+        );
+        let reward_amount = ((distributor.acc_reward_per_share - token.last_acc_reward_per_share) * (token.value as u128)) / DECIMAL_MULTIPLIER;
+        let reward_amount = (reward_amount as u64);
+
+        reward_amount
+    }
+
+    public fun get_quoter<R, W>(distributor: &RewardDistributor<R, W>): RewardDistributionQuoter {
+        reward_quoter::new(distributor.id, coin::value(&distributor.reward), distributor.total_token_amount, distributor.acc_reward_per_share)
+    }
+
+    #[test_only]
+    /// destroy a distributor for for test only.
+    /// the reward will be deposit into the sender account.
+    public fun destroy_for_test<R, W>(distributor: RewardDistributor<R, W>): Coin<R> {
+        let RewardDistributor {
+            id: _,
+            total_token_amount: _,
+            reward,
+            acc_reward_per_share: _
+        } = distributor;
+
+        reward
+    }
+
+    /*********************************/
+    /* RedeemToken Related functions */
+    /*********************************/
+    public fun token_value<R, W>(token: &RedeemToken<R, W>): u64 {
+        token.value
+    }
+
+    public fun token_id<R, W>(token: &RedeemToken<R, W>): u128 {
+        token.id
+    }
+
+    public fun token_last_acc_reward_per_share<R, W>(token: &RedeemToken<R, W>): u128 {
+        token.last_acc_reward_per_share
+    }
+
+    /// check if two tokens are fungible.
+    /// if they are fungible, they can be merged.
+    public fun is_fungible<R, W>(l: &RedeemToken<R, W>, r: &RedeemToken<R, W>): bool {
+        l.id == r.id && l.last_acc_reward_per_share == r.last_acc_reward_per_share
+    }
+
+    /// extract amount of token
+    public fun token_extract<R, W>(t: &mut RedeemToken<R, W>, amount: u64): RedeemToken<R, W> {
+        t.value = t.value - amount;
+        RedeemToken<R, W> {
+            value: amount,
+            id: t.id,
+            last_acc_reward_per_share: t.last_acc_reward_per_share,
+        }
+    }
+
+    /// merge two tokens.
+    /// they must be fungible
+    public fun token_merge<R, W>(t: &mut RedeemToken<R, W>, r: RedeemToken<R, W>) {
+        assert!(
+            is_fungible(t, &r),
+            E_REDEEM_TOKEN_NOT_FUNGIBLE,
+        );
+
+        t.value = t.value + r.value;
+
+        r.value = 0;
+
+        destroy_zero_token(r);
+    }
+
+    public fun destroy_zero_token<R, W>(t: RedeemToken<R, W>) {
+        assert!(
+            t.value == 0,
+            E_CANNOT_DESTROY_NON_ZERO_REDEEM_TOKEN,
+        );
+
+        let RedeemToken {
+            value: _,
+            id: _,
+            last_acc_reward_per_share: _,
+        } = t;
+    }
+
+    // melt two tokens into one. there will be loss for the user due to rounding.
+    public fun token_melt<R, W>(l: &mut RedeemToken<R, W>, r: RedeemToken<R, W>) {
+        assert!(
+            l.id == r.id,
+            E_CANNOT_MELT_TOKEN_FOR_DIFFERNT_DISTRIBUTOR,
+        );
+
+        let RedeemToken {
+            id: _,
+            value: r_value,
+            last_acc_reward_per_share: r_acc,
+        } = r;
+        let r_value = (r_value as u128);
+        let l_value = (l.value as u128);
+        let l_acc = l.last_acc_reward_per_share;
+
+        let old_acc = l_value * l_acc + r_value * r_acc;
+        let total_value = l_value + r_value;
+        let new_acc = old_acc / total_value;
+        if (new_acc * total_value < old_acc) {
+            new_acc = new_acc + 1;
+        };
+
+        l.value = (total_value as u64);
+        l.last_acc_reward_per_share = new_acc;
+    }
+}

--- a/aptos/contract/aux/sources/reward_distributor_test.move
+++ b/aptos/contract/aux/sources/reward_distributor_test.move
@@ -1,0 +1,176 @@
+#[test_only]
+module aux::reward_distributor_test {
+    use std::signer;
+    use aptos_framework::account;
+    use aptos_framework::coin;
+    use aptos_framework::timestamp;
+
+    use deployer::deployer::create_resource_account;
+
+    use aux::fake_coin::{Self, USDC, FakeCoin};
+    use aux::authority;
+    use aux::reward_distributor::{
+        create_reward_distributor,
+        add_reward,
+        mint,
+        burn,
+        rebase,
+        token_merge,
+        token_melt,
+        token_extract,
+        shutdown,
+        acc_reward_per_share,
+        is_fungible,
+        token_value,
+        token_last_acc_reward_per_share,
+        total_token_amount,
+        check_redeem_token,
+    };
+
+    struct Witness {}
+
+    fun setup_user(sender: &signer) {
+         let sender_addr = signer::address_of(sender);
+         if (!account::exists_at(sender_addr)) {
+             account::create_account_for_test(sender_addr);
+         };
+    }
+    fun setup(sender: &signer, aux: &signer, alice: &signer, bob: &signer, aptos_framework: &signer) {
+        timestamp::set_time_has_started_for_testing(aptos_framework);
+        setup_user(sender);
+        setup_user(alice);
+        setup_user(bob);
+
+        if (!account::exists_at(@aux)) {
+            create_resource_account(sender, b"amm");
+            authority::init_module_for_test(&deployer::deployer::get_signer_for_address(sender, @aux));
+        };
+        fake_coin::initialize_for_test(aux);
+    }
+
+    #[test(sender = @0x5e7c3, aux = @aux, alice = @0x123, bob = @0x124, aptos_framework = @0x1)]
+    fun test_reward_distributor(sender: &signer, aux: &signer, alice: &signer, bob: &signer, aptos_framework: &signer) {
+        setup(sender, aux, alice, bob, aptos_framework);
+
+        let multiplier = 1000000000; // 1000 USDC
+        let ten_to_12: u128 = 1000000000000;
+        fake_coin::register_and_mint<USDC>(sender, 2000 * multiplier);
+
+        let pool = create_reward_distributor<FakeCoin<USDC>, Witness>(aux, 0);
+
+        // add 100,000 USDC to the reward pool.
+        // no redeem token yet... so this goes no where
+        add_reward(&mut pool, coin::withdraw<FakeCoin<USDC>>(sender, 100 * multiplier));
+        assert!(acc_reward_per_share(&pool) == 0, 1);
+        // add 100 redeem tokens
+        let redeem_token_1 = mint(&mut pool, 100);
+        // add 500,000 USDC, so each redeem_token_1 should have 5,000,000,000,000,000,000,000 share
+        // redeem_token_1's last_acc_per_share is 0.
+        add_reward(&mut pool, coin::withdraw<FakeCoin<USDC>>(sender, 500 * multiplier));
+        let first_acc = 500*(multiplier as u128)/100 * ten_to_12;
+        assert!(token_last_acc_reward_per_share(&redeem_token_1) == 0, 0);
+        // extract from redeem_token_1_1
+        let redeem_token_1_1 = token_extract(&mut redeem_token_1, 30);
+
+        // extract and then merge back
+        let redeem_token_1_2 = token_extract(&mut redeem_token_1, 15);
+        token_merge(&mut redeem_token_1, redeem_token_1_2);
+        assert!(token_value(&redeem_token_1) == 70, token_value(&redeem_token_1));
+
+        // extract and burn
+        let c1 = burn(&mut pool, token_extract(&mut redeem_token_1, 15));
+        assert!(coin::value(&c1) == 5 * 15 * multiplier, coin::value(&c1));
+
+        // rebase token here.
+        let redeem_token_1_3 = token_extract(&mut redeem_token_1, 15);
+        let (c2, redeem_token_1_3) = rebase(&mut pool, redeem_token_1_3);
+        assert!(coin::value(&c1) == 5 * 15 * multiplier, coin::value(&c2));
+
+        assert!(token_last_acc_reward_per_share(&redeem_token_1_3) == first_acc, 3);
+        // now r1 and r1_3 cannot be fungible
+        assert!(!is_fungible(&redeem_token_1, &redeem_token_1_3), 1);
+
+        // let's melt r1_3 and r1_1
+        token_melt(&mut redeem_token_1_1, redeem_token_1_3);
+        assert!(token_last_acc_reward_per_share(&redeem_token_1_1) == (first_acc/3) + 1, 5);
+
+        // total token supply is 100 - 15 = 85
+        assert!(total_token_amount(&pool) == 85, (total_token_amount(&pool) as u64));
+
+        let redeem_token_2 = mint(&mut pool, 65);
+        add_reward(&mut pool, coin::withdraw<FakeCoin<USDC>>(sender, 250 * multiplier));
+        assert!(total_token_amount(&pool) == 150, 9);
+        assert!(acc_reward_per_share(&pool) == first_acc + (250*(multiplier as u128)*ten_to_12)/150, 3);
+
+        assert!(!is_fungible(&redeem_token_1, &redeem_token_2), 1);
+
+        // burn all tokens
+        assert!(token_value(&redeem_token_1) == 40, token_value(&redeem_token_1));
+        let c3 = burn(&mut pool, redeem_token_1);
+        assert!(coin::value(&c3) == (250 * multiplier * 40) / 150 + 5 * multiplier * 40, 5);
+        let c4 = burn(&mut pool, redeem_token_2);
+        assert!(coin::value(&c4) == (250 * multiplier * 65) / 150, 5);
+        let c5 = burn(&mut pool, redeem_token_1_1);
+        assert!(coin::value(&c5) == (250 * multiplier * 45) / 150 + 5 * multiplier * 30 - 1, coin::value(&c5));
+        let c = shutdown(pool);
+        assert!(coin::value(&c) == 2 + 100 * multiplier, coin::value(&c));
+
+        fake_coin::register<USDC>(alice);
+        coin::deposit(signer::address_of(alice), c);
+        coin::deposit(signer::address_of(alice), c1);
+        coin::deposit(signer::address_of(alice), c2);
+        coin::deposit(signer::address_of(alice), c3);
+        coin::deposit(signer::address_of(alice), c4);
+        coin::deposit(signer::address_of(alice), c5);
+    }
+
+    #[test(sender = @0x5e7c3, aux = @aux, alice = @0x123, bob = @0x124, aptos_framework = @0x1)]
+    #[expected_failure(abort_code = 1002, location = aux::reward_distributor)]
+    fun test_two_distributors_burn(sender: &signer, aux: &signer, alice: &signer, bob: &signer, aptos_framework: &signer) {
+        setup(sender, aux, alice, bob, aptos_framework);
+
+        let multiplier = 1000000000; // 1000 USDC
+        fake_coin::register_and_mint<USDC>(sender, 2000 * multiplier);
+
+        let pool0 = create_reward_distributor<FakeCoin<USDC>, Witness>(aux, 0);
+        let pool1 = create_reward_distributor<FakeCoin<USDC>, Witness>(aux, 1);
+
+        let redeem_token_0 = mint(&mut pool0, 100);
+        let redeem_token_1 = mint(&mut pool1, 100);
+
+        assert!(!check_redeem_token(&pool0, &redeem_token_1), 1);
+        let c1 = burn(&mut pool0, redeem_token_1);
+        let c2 = burn(&mut pool1, redeem_token_0);
+
+        coin::merge(&mut c1, shutdown(pool0));
+        coin::merge(&mut c2, shutdown(pool1));
+        coin::deposit(signer::address_of(sender), c1);
+        coin::deposit(signer::address_of(sender), c2)
+    }
+
+    #[test(sender = @0x5e7c3, aux = @aux, alice = @0x123, bob = @0x124, aptos_framework = @0x1)]
+    #[expected_failure(abort_code = 1002, location = aux::reward_distributor)]
+    fun test_two_distributors_rebase(sender: &signer, aux: &signer, alice: &signer, bob: &signer, aptos_framework: &signer) {
+        setup(sender, aux, alice, bob, aptos_framework);
+
+        let multiplier = 1000000000; // 1000 USDC
+        fake_coin::register_and_mint<USDC>(sender, 2000 * multiplier);
+
+        let pool1 = create_reward_distributor<FakeCoin<USDC>, Witness>(aux, 0);
+        let pool2 = create_reward_distributor<FakeCoin<USDC>, Witness>(aux, 1);
+
+        let redeem_token_1 = mint(&mut pool1, 100);
+        let redeem_token_2 = mint(&mut pool2, 100);
+
+        assert!(!check_redeem_token(&pool1, &redeem_token_2), 1);
+        let (c1, r1) = rebase(&mut pool2, redeem_token_1);
+        let (c2, r2) = rebase(&mut pool1, redeem_token_2);
+        coin::merge(&mut c1, burn(&mut pool1, r1));
+        coin::merge(&mut c2, burn(&mut pool2, r2));
+
+        coin::merge(&mut c1, shutdown(pool1));
+        coin::merge(&mut c2, shutdown(pool2));
+        coin::deposit(signer::address_of(sender), c1);
+        coin::deposit(signer::address_of(sender), c2)
+    }
+}

--- a/aptos/contract/aux/sources/reward_quoter.move
+++ b/aptos/contract/aux/sources/reward_quoter.move
@@ -1,0 +1,334 @@
+// Auto generated from "go-util/aptos/cmd/gen-reward-distributor"
+// Modify Manually with Caution
+// Quoter version use aux::quote_coin instead of real coin,
+// and can be used to perform calculations.
+module aux::reward_quoter {
+    use aux::quote_coin::{Self};
+
+    const E_MISMATCH_DISTRIBUTOR_ID: u64 = 1002;
+    const E_CANNOT_CREATE_DISTRIBUTOR_FOR_OTHER: u64 = 1003;
+    const E_ZERO_MINT_AMOUNT: u64 = 1004;
+    const E_CANNOT_SHUTDOWN_DISTRIBUTOR_WITH_OUTSTANDING_TOKEN: u64 = 1005;
+    const E_REDEEM_TOKEN_NOT_FUNGIBLE: u64 = 1006;
+    const E_CANNOT_DESTROY_NON_ZERO_REDEEM_TOKEN: u64 = 1007;
+    const E_CANNOT_MELT_TOKEN_FOR_DIFFERNT_DISTRIBUTOR: u64 = 1008;
+
+    const DECIMAL_MULTIPLIER: u128 = 1000000000000;
+
+    /// RewardDistributionQuoter is a primitive for distributing rewards to token holders.
+    ///
+    /// Reward is given out in the form of aux::quote_quote_coin::u64.
+    ///
+    /// RewardDistributionQuoter keeps track of acc_reward_per_share, that is,
+    /// the amount of reward per unit token if that token exists since the initialization of the distributor.
+    /// When reward is added to the RewardDistrubitor,
+    /// acc_reward_per_share is increased by the amount of added_reward / total_token_amount.
+    ///
+    /// Users' rewards are represented by QuoterRedeemToken.
+    /// Users are entitled to rewards that are added after their QuoterRedeemToken are mint.
+    /// This is ensured by keeping in QuoterRedeemToken last_acc_reward_per_share, which is the
+    /// acc_reward_per_share when the QuoterRedeemToken is minted.
+    /// When QuoterRedeemTokens are burned, the returned reward will be based on
+    /// current RewardDistributionQuoter's acc_reward_per_share minus QuoterRedeemToken's last_acc_reward_per_share.
+    ///
+    /// In reality, acc_reward_per_share is multiplied by 10^12 to increase the precision of calculations.
+    /// However, rounding is unavoidable, and there may still be reward left when total token amount is 0.
+    ///
+    /// When total token amount drops to 0, RewardDistributionQuoter can be shutdown and rewards returned to the authority
+    /// of the distributor.
+    ///
+    /// W is the witness type. Only owner of the witness type can create a RewardDistributionQuoter with W.
+    ///
+    /// There can be multiple RewardDistributionQuoters for the same reward coin R and witness W. They are differentiated by their id.
+    /// Each RewardDistributionQuoter has separate authority even if they are of same reward coin R.
+    struct RewardDistributionQuoter has store, copy, drop {
+        id: u128,
+        /// reward coins
+        reward: u64,
+        /// total_token_amount is the **current** outstanding QuoterRedeemToken for this distributor.
+        total_token_amount: u128,
+        /// accumulative reward per share, if the token is held from initialization of the pool.
+        acc_reward_per_share: u128,
+    }
+
+    /// QuoterRedeemToken contains the information useful for redeeming reward from RewardDistributionQuoter.
+    ///
+    /// It contains the number of tokens, and the `last_acc_reward_per_share`.
+    /// When QuoterRedeemToken is burned, reward will be calculated based on
+    /// value * (reward_distributor.acc_reward_per_share - token.last_acc_reward_per_share) / DECIMAL_MULTIPLIER.
+    struct QuoterRedeemToken has store, copy, drop {
+        // id of the distributor
+        id: u128,
+        value: u64,
+        last_acc_reward_per_share: u128,
+    }
+
+    /// create a new RewardDistributionQuoter
+    public fun create_quoter(id: u128, reward: u64, total_token_amount: u128, acc_reward_per_share: u128): RewardDistributionQuoter {
+        RewardDistributionQuoter {
+            id,
+            reward: quote_coin::new(reward),
+            total_token_amount,
+            acc_reward_per_share,
+        }
+    }
+
+    /// Add rewards to the distributor.
+    ///
+    /// To make sure no front running, only add reward when all the current token holders are entitled to the rewards.
+    /// For example, if a liquidity pool is using RewardDistributionQuoter to distribute fees to its lps.
+    /// The fees should be added to the pool **BEFORE** lp tokens are minted or burned.
+    ///
+    /// Note this function permits anyone to add reward to the pool.
+    /// Once the reward is added, there is no way to retrieve the reward before all tokens are redeemed/burned.
+    ///
+    /// If the total token amount is 0, the reward will be not able to be redeemable for users.
+    public fun add_reward(distributor: &mut RewardDistributionQuoter, reward: u64) {
+        let value = (quote_coin::value(&reward) as u128);
+
+        quote_coin::merge(&mut distributor.reward, reward);
+
+        // only increment the acc_reward_per_share when total token amount > 0.
+        // this means the reward will stuck in the distributor if total token amount is 0.
+        // the authority of the pool can still retrieve the reward once there is no outstanding token holders.
+        if (distributor.total_token_amount > 0) {
+            distributor.acc_reward_per_share = distributor.acc_reward_per_share + (value * DECIMAL_MULTIPLIER)/distributor.total_token_amount;
+        }
+    }
+
+    /// mint new redeem tokens.
+    public fun mint(
+        distributor: &mut RewardDistributionQuoter,
+        amount: u64,
+    ): QuoterRedeemToken
+    {
+        assert!(amount > 0, E_ZERO_MINT_AMOUNT);
+
+        distributor.total_token_amount = distributor.total_token_amount + (amount as u128);
+
+        QuoterRedeemToken {
+            id: distributor.id,
+            value: amount,
+            last_acc_reward_per_share: distributor.acc_reward_per_share,
+        }
+    }
+
+    /// burn QuoterRedeemTokens and get reward
+    public fun burn(
+        distributor: &mut RewardDistributionQuoter,
+        tokens: QuoterRedeemToken,
+    ): u64 {
+        assert!(tokens.id == distributor.id, E_MISMATCH_DISTRIBUTOR_ID);
+
+        distributor.total_token_amount = distributor.total_token_amount - (tokens.value as u128);
+        let reward_amount = ((distributor.acc_reward_per_share - tokens.last_acc_reward_per_share) * (tokens.value as u128)) / DECIMAL_MULTIPLIER;
+        let reward_amount = (reward_amount as u64);
+
+        let rewards = quote_coin::extract(&mut distributor.reward, reward_amount);
+
+        let QuoterRedeemToken {
+            value: _,
+            id: _,
+            last_acc_reward_per_share: _,
+        } = tokens;
+
+        rewards
+    }
+
+    /// rebase will withdraw the current reward amount, and
+    /// replace the old token with new tokens.
+    public fun rebase(
+        distributor: &mut RewardDistributionQuoter,
+        tokens: QuoterRedeemToken,
+    ): (u64, QuoterRedeemToken) {
+        assert!(tokens.id == distributor.id, E_MISMATCH_DISTRIBUTOR_ID);
+
+        let reward_amount = ((distributor.acc_reward_per_share - tokens.last_acc_reward_per_share) * (tokens.value as u128)) / DECIMAL_MULTIPLIER;
+        let reward_amount = (reward_amount as u64);
+
+        let rewards = quote_coin::extract(&mut distributor.reward, reward_amount);
+
+         let QuoterRedeemToken {
+            value,
+            id,
+            last_acc_reward_per_share: _,
+        } = tokens;
+
+        (
+            rewards,
+            QuoterRedeemToken {
+                value,
+                id,
+                last_acc_reward_per_share: distributor.acc_reward_per_share,
+            },
+        )
+    }
+
+    /// shutdown the distributor. The total outstanding token amount must be 0.
+    public fun shutdown(distributor: RewardDistributionQuoter): u64 {
+        assert!(
+            distributor.total_token_amount == 0,
+            E_CANNOT_SHUTDOWN_DISTRIBUTOR_WITH_OUTSTANDING_TOKEN,
+        );
+
+        let RewardDistributionQuoter {
+            reward: remaining_rewards,
+            id: _,
+            total_token_amount: _,
+            acc_reward_per_share: _,
+        } = distributor;
+
+        remaining_rewards
+    }
+
+    /*********************************/
+    /* RewardDistributionQuoter functions   */
+    /*********************************/
+
+    public fun acc_reward_per_share(distributor: &RewardDistributionQuoter): u128 {
+        distributor.acc_reward_per_share
+    }
+
+    public fun distributor_id(distributor: &RewardDistributionQuoter): u128 {
+        distributor.id
+    }
+
+    public fun total_token_amount(distributor: &RewardDistributionQuoter): u128 {
+        distributor.total_token_amount
+    }
+
+    public fun available_reward(distributor: &RewardDistributionQuoter): u64 {
+        quote_coin::value(&distributor.reward)
+    }
+
+    /// check if token is for this RewardDistributionQuoter
+    public fun check_redeem_token(distributor: &RewardDistributionQuoter, token: &QuoterRedeemToken): bool {
+        distributor.id == token.id
+    }
+
+    /// compute the reward amount for the given token.
+    public fun reward_amount(distributor: &RewardDistributionQuoter, token: &QuoterRedeemToken): u64 {
+        assert!(
+            distributor.id == token.id,
+            E_MISMATCH_DISTRIBUTOR_ID,
+        );
+        let reward_amount = ((distributor.acc_reward_per_share - token.last_acc_reward_per_share) * (token.value as u128)) / DECIMAL_MULTIPLIER;
+        let reward_amount = (reward_amount as u64);
+
+        reward_amount
+    }
+
+    public fun new(id: u128, reward: u64, total_token_amount: u128, acc_reward_per_share: u128): RewardDistributionQuoter {
+        RewardDistributionQuoter {
+            id,
+            reward: quote_coin::new(reward),
+            total_token_amount,
+            acc_reward_per_share,
+        }
+    }
+
+    /*********************************/
+    /* QuoterRedeemToken Related functions */
+    /*********************************/
+
+    // quoter allows arbitrary creation of redeem tokens.
+    public fun token_new(id: u128, value: u64, last_acc_reward_per_share: u128): QuoterRedeemToken {
+        QuoterRedeemToken {
+            id,
+            value,
+            last_acc_reward_per_share,
+        }
+    }
+
+    // quoter allows destroy of any redeem tokens.
+    public fun token_destroy(token: QuoterRedeemToken) {
+        let QuoterRedeemToken {
+            id: _,
+            value: _,
+            last_acc_reward_per_share: _,
+        } = token;
+    }
+
+    public fun token_value(token: &QuoterRedeemToken): u64 {
+        token.value
+    }
+
+    public fun token_id(token: &QuoterRedeemToken): u128 {
+        token.id
+    }
+
+    public fun token_last_acc_reward_per_share(token: &QuoterRedeemToken): u128 {
+        token.last_acc_reward_per_share
+    }
+
+    /// check if two tokens are fungible.
+    /// if they are fungible, they can be merged.
+    public fun is_fungible(l: &QuoterRedeemToken, r: &QuoterRedeemToken): bool {
+        l.id == r.id && l.last_acc_reward_per_share == r.last_acc_reward_per_share
+    }
+
+    /// extract amount of token
+    public fun token_extract(t: &mut QuoterRedeemToken, amount: u64): QuoterRedeemToken {
+        t.value = t.value - amount;
+        QuoterRedeemToken {
+            value: amount,
+            id: t.id,
+            last_acc_reward_per_share: t.last_acc_reward_per_share,
+        }
+    }
+
+    /// merge two tokens.
+    /// they must be fungible
+    public fun token_merge(t: &mut QuoterRedeemToken, r: QuoterRedeemToken) {
+        assert!(
+            is_fungible(t, &r),
+            E_REDEEM_TOKEN_NOT_FUNGIBLE,
+        );
+
+        t.value = t.value + r.value;
+
+        r.value = 0;
+
+        destroy_zero_token(r);
+    }
+
+    public fun destroy_zero_token(t: QuoterRedeemToken) {
+        assert!(
+            t.value == 0,
+            E_CANNOT_DESTROY_NON_ZERO_REDEEM_TOKEN,
+        );
+
+        let QuoterRedeemToken {
+            value: _,
+            id: _,
+            last_acc_reward_per_share: _,
+        } = t;
+    }
+
+    // melt two tokens into one. there will be loss for the user due to rounding.
+    public fun token_melt(l: &mut QuoterRedeemToken, r: QuoterRedeemToken) {
+        assert!(
+            l.id == r.id,
+            E_CANNOT_MELT_TOKEN_FOR_DIFFERNT_DISTRIBUTOR,
+        );
+
+        let QuoterRedeemToken {
+            id: _,
+            value: r_value,
+            last_acc_reward_per_share: r_acc,
+        } = r;
+        let r_value = (r_value as u128);
+        let l_value = (l.value as u128);
+        let l_acc = l.last_acc_reward_per_share;
+
+        let old_acc = l_value * l_acc + r_value * r_acc;
+        let total_value = l_value + r_value;
+        let new_acc = old_acc / total_value;
+        if (new_acc * total_value < old_acc) {
+            new_acc = new_acc + 1;
+        };
+
+        l.value = (total_value as u64);
+        l.last_acc_reward_per_share = new_acc;
+    }
+}

--- a/go-util/aptos/cmd/gen-reward-distributor/main.go
+++ b/go-util/aptos/cmd/gen-reward-distributor/main.go
@@ -1,0 +1,74 @@
+package main
+
+import (
+	"bytes"
+	_ "embed"
+	"os"
+	"text/template"
+
+	"github.com/spf13/cobra"
+)
+
+//go:embed reward_distributor.move.template
+var rewardDistributorTemplate string
+
+type RewardDistributorData struct {
+	IsNotQuote bool
+	ModuleName string
+	ClassName  string
+	TokenName  string
+	CoinModule string
+}
+
+func NewRewardDistributorData(IsNotQuote bool) *RewardDistributorData {
+	r := &RewardDistributorData{IsNotQuote: IsNotQuote}
+
+	if IsNotQuote {
+		r.ModuleName = "reward_distributor"
+		r.ClassName = "RewardDistributor"
+		r.TokenName = "RedeemToken"
+		r.CoinModule = "coin"
+	} else {
+		r.ModuleName = "reward_quoter"
+		r.ClassName = "RewardDistributionQuoter"
+		r.TokenName = "QuoterRedeemToken"
+		r.CoinModule = "quote_coin"
+	}
+	return r
+}
+
+func main() {
+	cmd := &cobra.Command{
+		Use:   "reward-distributor-gen",
+		Short: "generate reward distributor code.",
+		Args:  cobra.NoArgs,
+	}
+
+	output := ""
+	isQuote := false
+	cmd.Flags().StringVarP(&output, "output", "o", output, "output file")
+	cmd.MarkFlagFilename("output")
+	cmd.MarkFlagRequired("output")
+	cmd.Flags().BoolVarP(&isQuote, "is-quote", "q", isQuote, "for quote")
+
+	cmd.Run = func(*cobra.Command, []string) {
+		tmpl, err := template.New("tmp").Parse(rewardDistributorTemplate)
+		if err != nil {
+			panic(err)
+		}
+
+		v := NewRewardDistributorData(!isQuote)
+
+		var buf bytes.Buffer
+
+		if err := tmpl.Execute(&buf, v); err != nil {
+			panic(err)
+		}
+
+		if err := os.WriteFile(output, buf.Bytes(), 0o666); err != nil {
+			panic(err)
+		}
+	}
+
+	cmd.Execute()
+}

--- a/go-util/aptos/cmd/gen-reward-distributor/reward_distributor.move.template
+++ b/go-util/aptos/cmd/gen-reward-distributor/reward_distributor.move.template
@@ -1,0 +1,371 @@
+// Auto generated from "go-util/aptos/cmd/gen-reward-distributor"
+// Modify Manually with Caution
+{{if not .IsNotQuote}}// Quoter version use aux::quote_coin instead of real coin,
+// and can be used to perform calculations.
+{{end}}module aux::{{.ModuleName}} {
+{{$coinName := "Coin"}}{{$rewardParam := "<R>"}}{{$typeParam := "<R, W>"}}{{if .IsNotQuote}}    use std::signer;
+
+    use aptos_framework::{{.CoinModule}}::{Self, Coin};
+    use aptos_framework::type_info;
+    use aux::reward_quoter::{Self, RewardDistributionQuoter};
+{{else}}{{$rewardParam = ""}}{{$typeParam = ""}}{{$coinName = "u64"}}    use aux::{{.CoinModule}}::{Self};
+{{end}}
+    const E_MISMATCH_DISTRIBUTOR_ID: u64 = 1002;
+    const E_CANNOT_CREATE_DISTRIBUTOR_FOR_OTHER: u64 = 1003;
+    const E_ZERO_MINT_AMOUNT: u64 = 1004;
+    const E_CANNOT_SHUTDOWN_DISTRIBUTOR_WITH_OUTSTANDING_TOKEN: u64 = 1005;
+    const E_REDEEM_TOKEN_NOT_FUNGIBLE: u64 = 1006;
+    const E_CANNOT_DESTROY_NON_ZERO_REDEEM_TOKEN: u64 = 1007;
+    const E_CANNOT_MELT_TOKEN_FOR_DIFFERNT_DISTRIBUTOR: u64 = 1008;
+
+    const DECIMAL_MULTIPLIER: u128 = 1000000000000;
+
+    /// {{.ClassName}} is a primitive for distributing rewards to token holders.
+    ///
+    /// Reward is given out in the form of {{if .IsNotQuote}}0x1::{{.CoinModule}}::{{$coinName}}<R>{{else}}aux::quote_{{.CoinModule}}::{{$coinName}}{{end}}.
+    ///
+    /// {{.ClassName}} keeps track of acc_reward_per_share, that is,
+    /// the amount of reward per unit token if that token exists since the initialization of the distributor.
+    /// When reward is added to the RewardDistrubitor,
+    /// acc_reward_per_share is increased by the amount of added_reward / total_token_amount.
+    ///
+    /// Users' rewards are represented by {{.TokenName}}.
+    /// Users are entitled to rewards that are added after their {{.TokenName}} are mint.
+    /// This is ensured by keeping in {{.TokenName}} last_acc_reward_per_share, which is the
+    /// acc_reward_per_share when the {{.TokenName}} is minted.
+    /// When {{.TokenName}}s are burned, the returned reward will be based on
+    /// current {{.ClassName}}'s acc_reward_per_share minus {{.TokenName}}'s last_acc_reward_per_share.
+    ///
+    /// In reality, acc_reward_per_share is multiplied by 10^12 to increase the precision of calculations.
+    /// However, rounding is unavoidable, and there may still be reward left when total token amount is 0.
+    ///
+    /// When total token amount drops to 0, {{.ClassName}} can be shutdown and rewards returned to the authority
+    /// of the distributor.
+    ///
+    /// W is the witness type. Only owner of the witness type can create a {{.ClassName}} with W.
+    ///
+    /// There can be multiple {{.ClassName}}s for the same reward coin R and witness W. They are differentiated by their id.
+    /// Each {{.ClassName}} has separate authority even if they are of same reward coin R.
+    struct {{.ClassName}}{{if .IsNotQuote}}<phantom R, phantom W>{{end}} has store{{if not .IsNotQuote}}, copy, drop{{end}} {
+        id: u128,
+        /// reward coins
+        reward: {{$coinName}}{{$rewardParam}},
+        /// total_token_amount is the **current** outstanding {{.TokenName}} for this distributor.
+        total_token_amount: u128,
+        /// accumulative reward per share, if the token is held from initialization of the pool.
+        acc_reward_per_share: u128,
+    }
+
+    /// {{.TokenName}} contains the information useful for redeeming reward from {{.ClassName}}.
+    ///
+    /// It contains the number of tokens, and the `last_acc_reward_per_share`.
+    /// When {{.TokenName}} is burned, reward will be calculated based on
+    /// value * (reward_distributor.acc_reward_per_share - token.last_acc_reward_per_share) / DECIMAL_MULTIPLIER.
+    struct {{.TokenName}}{{if .IsNotQuote}}<phantom R, phantom W>{{end}} has store{{if not .IsNotQuote}}, copy, drop{{end}} {
+        // id of the distributor
+        id: u128,
+        value: u64,
+        last_acc_reward_per_share: u128,
+    }
+{{if .IsNotQuote}}
+    /// create a new {{.ClassName}}.
+    public fun create_reward_distributor{{$typeParam}}(sender: &signer, id: u128): {{.ClassName}}{{$typeParam}} {
+        assert!(
+            signer::address_of(sender) == type_info::account_address(&type_info::type_of<W>()),
+            E_CANNOT_CREATE_DISTRIBUTOR_FOR_OTHER,
+        );
+        {{.ClassName}} {
+            id,
+            reward: {{.CoinModule}}::zero(),
+            total_token_amount: 0,
+            acc_reward_per_share: 0,
+        }
+    }
+{{else}}
+    /// create a new {{.ClassName}}
+    public fun create_quoter{{$typeParam}}(id: u128, reward: u64, total_token_amount: u128, acc_reward_per_share: u128): {{.ClassName}}{{$typeParam}} {
+        {{.ClassName}} {
+            id,
+            reward: {{.CoinModule}}::new(reward),
+            total_token_amount,
+            acc_reward_per_share,
+        }
+    }
+{{end}}
+    /// Add rewards to the distributor.
+    ///
+    /// To make sure no front running, only add reward when all the current token holders are entitled to the rewards.
+    /// For example, if a liquidity pool is using {{.ClassName}} to distribute fees to its lps.
+    /// The fees should be added to the pool **BEFORE** lp tokens are minted or burned.
+    ///
+    /// Note this function permits anyone to add reward to the pool.
+    /// Once the reward is added, there is no way to retrieve the reward before all tokens are redeemed/burned.
+    ///
+    /// If the total token amount is 0, the reward will be not able to be redeemable for users.
+    public fun add_reward{{$typeParam}}(distributor: &mut {{.ClassName}}{{$typeParam}}, reward: {{$coinName}}{{$rewardParam}}) {
+        let value = ({{.CoinModule}}::value(&reward) as u128);
+
+        {{.CoinModule}}::merge(&mut distributor.reward, reward);
+
+        // only increment the acc_reward_per_share when total token amount > 0.
+        // this means the reward will stuck in the distributor if total token amount is 0.
+        // the authority of the pool can still retrieve the reward once there is no outstanding token holders.
+        if (distributor.total_token_amount > 0) {
+            distributor.acc_reward_per_share = distributor.acc_reward_per_share + (value * DECIMAL_MULTIPLIER)/distributor.total_token_amount;
+        }
+    }
+
+    /// mint new redeem tokens.
+    public fun mint{{$typeParam}}(
+        distributor: &mut {{.ClassName}}{{$typeParam}},
+        amount: u64,
+    ): {{.TokenName}}{{$typeParam}}
+    {
+        assert!(amount > 0, E_ZERO_MINT_AMOUNT);
+
+        distributor.total_token_amount = distributor.total_token_amount + (amount as u128);
+
+        {{.TokenName}} {
+            id: distributor.id,
+            value: amount,
+            last_acc_reward_per_share: distributor.acc_reward_per_share,
+        }
+    }
+
+    /// burn {{.TokenName}}s and get reward
+    public fun burn{{$typeParam}}(
+        distributor: &mut {{.ClassName}}{{$typeParam}},
+        tokens: {{.TokenName}}{{$typeParam}},
+    ): {{$coinName}}{{$rewardParam}} {
+        assert!(tokens.id == distributor.id, E_MISMATCH_DISTRIBUTOR_ID);
+
+        distributor.total_token_amount = distributor.total_token_amount - (tokens.value as u128);
+        let reward_amount = ((distributor.acc_reward_per_share - tokens.last_acc_reward_per_share) * (tokens.value as u128)) / DECIMAL_MULTIPLIER;
+        let reward_amount = (reward_amount as u64);
+
+        let rewards = {{.CoinModule}}::extract(&mut distributor.reward, reward_amount);
+
+        let {{.TokenName}} {
+            value: _,
+            id: _,
+            last_acc_reward_per_share: _,
+        } = tokens;
+
+        rewards
+    }
+
+    /// rebase will withdraw the current reward amount, and
+    /// replace the old token with new tokens.
+    public fun rebase{{$typeParam}}(
+        distributor: &mut {{.ClassName}}{{$typeParam}},
+        tokens: {{.TokenName}}{{$typeParam}},
+    ): ({{$coinName}}{{$rewardParam}}, {{.TokenName}}{{$typeParam}}) {
+        assert!(tokens.id == distributor.id, E_MISMATCH_DISTRIBUTOR_ID);
+
+        let reward_amount = ((distributor.acc_reward_per_share - tokens.last_acc_reward_per_share) * (tokens.value as u128)) / DECIMAL_MULTIPLIER;
+        let reward_amount = (reward_amount as u64);
+
+        let rewards = {{.CoinModule}}::extract(&mut distributor.reward, reward_amount);
+
+         let {{.TokenName}} {
+            value,
+            id,
+            last_acc_reward_per_share: _,
+        } = tokens;
+
+        (
+            rewards,
+            {{.TokenName}} {
+                value,
+                id,
+                last_acc_reward_per_share: distributor.acc_reward_per_share,
+            },
+        )
+    }
+
+    /// shutdown the distributor. The total outstanding token amount must be 0.
+    public fun shutdown{{$typeParam}}(distributor: {{.ClassName}}{{$typeParam}}): {{$coinName}}{{$rewardParam}} {
+        assert!(
+            distributor.total_token_amount == 0,
+            E_CANNOT_SHUTDOWN_DISTRIBUTOR_WITH_OUTSTANDING_TOKEN,
+        );
+
+        let {{.ClassName}}{{$typeParam}} {
+            reward: remaining_rewards,
+            id: _,
+            total_token_amount: _,
+            acc_reward_per_share: _,
+        } = distributor;
+
+        remaining_rewards
+    }
+
+    /*********************************/
+    /* {{.ClassName}} functions   */
+    /*********************************/
+
+    public fun acc_reward_per_share{{$typeParam}}(distributor: &{{.ClassName}}{{$typeParam}}): u128 {
+        distributor.acc_reward_per_share
+    }
+
+    public fun distributor_id{{$typeParam}}(distributor: &{{.ClassName}}{{$typeParam}}): u128 {
+        distributor.id
+    }
+
+    public fun total_token_amount{{$typeParam}}(distributor: &{{.ClassName}}{{$typeParam}}): u128 {
+        distributor.total_token_amount
+    }
+
+    public fun available_reward{{$typeParam}}(distributor: &{{.ClassName}}{{$typeParam}}): u64 {
+        {{.CoinModule}}::value(&distributor.reward)
+    }
+
+    /// check if token is for this {{.ClassName}}
+    public fun check_redeem_token{{$typeParam}}(distributor: &{{.ClassName}}{{$typeParam}}, token: &{{.TokenName}}{{$typeParam}}): bool {
+        distributor.id == token.id
+    }
+
+    /// compute the reward amount for the given token.
+    public fun reward_amount{{$typeParam}}(distributor: &{{.ClassName}}{{$typeParam}}, token: &{{.TokenName}}{{$typeParam}}): u64 {
+        assert!(
+            distributor.id == token.id,
+            E_MISMATCH_DISTRIBUTOR_ID,
+        );
+        let reward_amount = ((distributor.acc_reward_per_share - token.last_acc_reward_per_share) * (token.value as u128)) / DECIMAL_MULTIPLIER;
+        let reward_amount = (reward_amount as u64);
+
+        reward_amount
+    }
+{{if .IsNotQuote}}
+    public fun get_quoter{{$typeParam}}(distributor: &{{.ClassName}}{{$typeParam}}): RewardDistributionQuoter {
+        reward_quoter::new(distributor.id, {{.CoinModule}}::value(&distributor.reward), distributor.total_token_amount, distributor.acc_reward_per_share)
+    }
+
+    #[test_only]
+    /// destroy a distributor for for test only.
+    /// the reward will be deposit into the sender account.
+    public fun destroy_for_test{{$typeParam}}(distributor: {{.ClassName}}{{$typeParam}}): {{$coinName}}{{$rewardParam}} {
+        let {{.ClassName}} {
+            id: _,
+            total_token_amount: _,
+            reward,
+            acc_reward_per_share: _
+        } = distributor;
+
+        reward
+    }
+{{else}}
+    public fun new{{$typeParam}}(id: u128, reward: u64, total_token_amount: u128, acc_reward_per_share: u128): RewardDistributionQuoter{{$typeParam}} {
+        RewardDistributionQuoter {
+            id,
+            reward: {{.CoinModule}}::new(reward),
+            total_token_amount,
+            acc_reward_per_share,
+        }
+    }
+{{end}}
+    /*********************************/
+    /* {{.TokenName}} Related functions */
+    /*********************************/
+{{if not .IsNotQuote}}
+    // quoter allows arbitrary creation of redeem tokens.
+    public fun token_new{{$typeParam}}(id: u128, value: u64, last_acc_reward_per_share: u128): {{.TokenName}}{{$typeParam}} {
+        {{.TokenName}} {
+            id,
+            value,
+            last_acc_reward_per_share,
+        }
+    }
+
+    // quoter allows destroy of any redeem tokens.
+    public fun token_destroy{{$typeParam}}(token: {{.TokenName}}{{$typeParam}}) {
+        let {{.TokenName}} {
+            id: _,
+            value: _,
+            last_acc_reward_per_share: _,
+        } = token;
+    }
+
+{{end}}    public fun token_value{{$typeParam}}(token: &{{.TokenName}}{{$typeParam}}): u64 {
+        token.value
+    }
+
+    public fun token_id{{$typeParam}}(token: &{{.TokenName}}{{$typeParam}}): u128 {
+        token.id
+    }
+
+    public fun token_last_acc_reward_per_share{{$typeParam}}(token: &{{.TokenName}}{{$typeParam}}): u128 {
+        token.last_acc_reward_per_share
+    }
+
+    /// check if two tokens are fungible.
+    /// if they are fungible, they can be merged.
+    public fun is_fungible{{$typeParam}}(l: &{{.TokenName}}{{$typeParam}}, r: &{{.TokenName}}{{$typeParam}}): bool {
+        l.id == r.id && l.last_acc_reward_per_share == r.last_acc_reward_per_share
+    }
+
+    /// extract amount of token
+    public fun token_extract{{$typeParam}}(t: &mut {{.TokenName}}{{$typeParam}}, amount: u64): {{.TokenName}}{{$typeParam}} {
+        t.value = t.value - amount;
+        {{.TokenName}}{{$typeParam}} {
+            value: amount,
+            id: t.id,
+            last_acc_reward_per_share: t.last_acc_reward_per_share,
+        }
+    }
+
+    /// merge two tokens.
+    /// they must be fungible
+    public fun token_merge{{$typeParam}}(t: &mut {{.TokenName}}{{$typeParam}}, r: {{.TokenName}}{{$typeParam}}) {
+        assert!(
+            is_fungible(t, &r),
+            E_REDEEM_TOKEN_NOT_FUNGIBLE,
+        );
+
+        t.value = t.value + r.value;
+
+        r.value = 0;
+
+        destroy_zero_token(r);
+    }
+
+    public fun destroy_zero_token{{$typeParam}}(t: {{.TokenName}}{{$typeParam}}) {
+        assert!(
+            t.value == 0,
+            E_CANNOT_DESTROY_NON_ZERO_REDEEM_TOKEN,
+        );
+
+        let {{.TokenName}} {
+            value: _,
+            id: _,
+            last_acc_reward_per_share: _,
+        } = t;
+    }
+
+    // melt two tokens into one. there will be loss for the user due to rounding.
+    public fun token_melt{{$typeParam}}(l: &mut {{.TokenName}}{{$typeParam}}, r: {{.TokenName}}{{$typeParam}}) {
+        assert!(
+            l.id == r.id,
+            E_CANNOT_MELT_TOKEN_FOR_DIFFERNT_DISTRIBUTOR,
+        );
+
+        let {{.TokenName}} {
+            id: _,
+            value: r_value,
+            last_acc_reward_per_share: r_acc,
+        } = r;
+        let r_value = (r_value as u128);
+        let l_value = (l.value as u128);
+        let l_acc = l.last_acc_reward_per_share;
+
+        let old_acc = l_value * l_acc + r_value * r_acc;
+        let total_value = l_value + r_value;
+        let new_acc = old_acc / total_value;
+        if (new_acc * total_value < old_acc) {
+            new_acc = new_acc + 1;
+        };
+
+        l.value = (total_value as u64);
+        l.last_acc_reward_per_share = new_acc;
+    }
+}

--- a/go-util/generate.go
+++ b/go-util/generate.go
@@ -7,6 +7,10 @@ package aux_go_generate
 //go:generate go run github.com/fardream/gen-move-container@latest critbit -o ../aptos/contract/aux/sources/critbit_v.move -p aux -m critbit_v
 //go:generate go run github.com/fardream/gen-move-container@latest critbit -o ../aptos/contract/aux/sources/critbit.move -p aux -m critbit --use-aptos-table
 
+// reward distributor
+//go:generate go run ./aptos/cmd/gen-reward-distributor -o ../aptos/contract/aux/sources/reward_distributor.move
+//go:generate go run ./aptos/cmd/gen-reward-distributor -q -o ../aptos/contract/aux/sources/reward_quoter.move
+
 // abort-only-contract
 // Uncomment the below command to generate abort only contract
 // //go:generate go run ./cmd/move-abort -e authority.move -i ../aptos/contract/aux/sources -o ../aptos/abort-only-contract/aux/sources


### PR DESCRIPTION
feature(aux): reward distributor.

Reward Distributor is similar to `stake.move`, but is geared toward
primitive and lacks many of the functionalities of `stake.move`.
The intention is to distribute reward to users based on their share
amount, and when they got the shares. It is not intended to be used as
a standalone contract, rather, it is to be integrated into larger
modules where the reward is generated and distributed.

Also included is a `quote_coin.move`. Often, users want to perform
some calculations that involve `aptos_framework::coin::Coin`, such as
in RewardDistributor, estimate how much reward they can
get. `quote_coin` is a module that fully replicate the operations on
`Coin` (such as `merge`, `extract` etc), but anyone can arbitrarily
create and burn. This module can be used in place of coins so that the
same calculations can be performed. See `reward_quoter` for an example.